### PR TITLE
Add dot notation to `(define (f ...) ...)`

### DIFF
--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -170,6 +170,36 @@ let%test_unit "parse_define" =
             NumberInt 1;
         ])
         (Define ("x", NumberInt 1)));
+
+    ([%test_eq: node]
+        (parse_define
+        [
+            Symbol "define";
+            Pair (Symbol "f", Symbol "xs");
+            Symbol "xs";
+        ])
+        (Define (
+            "f",
+            Func ([Symbol "."; Symbol "xs"],
+            [Symbol "xs"]))));
+
+    ([%test_eq: node]
+        (parse_define
+        [
+            Symbol "define";
+            (Sequence [
+                Symbol "f";
+                Symbol "x"; Symbol "."; Symbol "xs";
+            ]);
+            Symbol "xs";
+        ])
+        (Define (
+            "f",
+            Func ([
+                Symbol "x"; Symbol "."; Symbol "xs";
+            ],
+            [Symbol "xs"]))));
+
     ([%test_eq: node]
         (parse_define
         [


### PR DESCRIPTION
Example code snippet:

```lisp
=> (define (f . xs) xs)
(lambda ...)
=> (f)
()
=> (f 1)
(1)
=> (f 1 2 3)
(1 2 3)
```

`(define (f x . xs))` works after merging #3, but `(define (f . xs))` doesn't. The error is fixed by modifying `parse_define`, where `(f . s)` is parsed into a `Pair`.

