### PR TITLE
Make compilation (`--compile ...`) works

### DIFF
--- a/lib/compiler.ml
+++ b/lib/compiler.ml
@@ -1,0 +1,24 @@
+open Ppx_compare_lib.Builtin
+open Sexplib.Std
+
+type ocaml_expr =
+    | Int of int
+    | Let of {name: string}
+    [@@deriving compare, sexp]
+
+let compile node =
+    if Evaluator.is_self_eval node
+    then (
+        match node with
+        (* | Parser.Bool (_) *)
+        (* | Parser.Func (_, _) *)
+        | Parser.NumberInt (value) -> Int value
+        (* | Parser.NumberFloat (_) *)
+        (* | Parser.String_ (_) -> true *)
+        | _ -> failwith "compile unreachable code"
+    )
+    else failwith "compile unreachable code"
+let%test_unit "compile" =
+    ([%test_eq: ocaml_expr]
+        (compile (Parser.NumberInt 2))
+        (Int 2))

--- a/lib/dune
+++ b/lib/dune
@@ -7,5 +7,5 @@
      ppx_assert
      ppx_compare
      ppx_sexp_conv))
- (modules Tokenizer Parser Evaluator)
+ (modules Tokenizer Parser Evaluator Compiler)
  (libraries str sexplib))


### PR DESCRIPTION
The end result is to make Camlisp able to compile arbitrary Scheme expressions from input file(s) to working OCaml code in a `.ml` file. For example, this Scheme function:

```lisp
(define (fact-iter n)
   (define (iter result n)
     (if (= n 1)
       result
       (iter (* result n) (- n 1))))
   (iter 1 n))
```

Should be compiled to:

```ocaml
let fact_iter n =
  let rec iter result n =
    if n = 1
    then result
    else iter (result * n) (n - 1)
  in (iter 1 n)
```

The plan is to compile the parsed `Parser.node` to `Compiler.ocaml_expr`.